### PR TITLE
Update mf_selectcore.c to correct a small typo

### DIFF
--- a/src/utilities/megaflash/mf_selectcore.c
+++ b/src/utilities/megaflash/mf_selectcore.c
@@ -198,7 +198,7 @@ uint8_t mfsc_load_dir(uint8_t new_dir)
   uint8_t fnlen, i, j, isroot = 0;
 
   // clear screen and display scanning message
-  mhx_draw_rect(6, 11, 26, 1, "Scanning directoy", MHX_A_WHITE|MHX_A_INVERT, 1);
+  mhx_draw_rect(6, 11, 26, 1, "Scanning directory", MHX_A_WHITE|MHX_A_INVERT, 1);
   mhx_set_xy(7, 12);
 
   // check if sd card is either not initialised or the wrong bus is selected


### PR DESCRIPTION
The message that appears after you press <F3> to "Load Core" has a typo.  It says "***Scanning directoy***" instead of "***Scanning directory***".  The typo has been corrected.